### PR TITLE
add indentation support

### DIFF
--- a/dts-mode.el
+++ b/dts-mode.el
@@ -67,6 +67,30 @@
 
     table))
 
+(defun dts--calculate-indentation ()
+  (interactive)
+  (save-excursion
+    (let ((end (point-at-eol))
+          (cnt 0)
+          (initial-point (point)))
+      (goto-char 0)
+      (while (re-search-forward "\\([{}]\\)" end t)
+        (if (string= (match-string-no-properties 0) "{")
+            (setq cnt (1+ cnt))
+          (setq cnt (1- cnt))))
+      ;; subtract one if the current line has an opening brace since we
+      ;; shouldn't add the indentation level until the following line
+      (goto-char initial-point)
+      (beginning-of-line)
+      (when (re-search-forward "{" (point-at-eol) t)
+        (setq cnt (1- cnt)))
+      cnt)))
+
+(defun dts-indent-line ()
+  (interactive)
+  (let ((indent (dts--calculate-indentation)))
+    (indent-line-to (* indent tab-width))))
+
 (defalias 'dts-parent-mode
   (if (fboundp 'prog-mode) 'prog-mode 'fundamental-mode))
 
@@ -82,7 +106,8 @@
   (set (make-local-variable 'comment-start) "/* ")
   (set (make-local-variable 'comment-end)   " */")
   (set (make-local-variable 'indent-tabs-mode) nil)
-  (set (make-local-variable 'comment-multi-line) t))
+  (set (make-local-variable 'comment-multi-line) t)
+  (set (make-local-variable 'indent-line-function) 'dts-indent-line))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.dts\\'" . dts-mode))


### PR DESCRIPTION
Add a simple indentation function that looks at nothing but opening and
closes braces.

Ideally we should use `smie' to do indentation, but this works for now.

Given the following file:

```
/ {
cpus {
cpu-map {
cluster1 {
core0 {
cpu = <&CPU0>;
};
core1 {
cpu = <&CPU1>;
};
};
};
};

widget: pizza,feast@a00000 {
compatible = "pizza,feast-v1";
things = <1 2 3>;
};
};
```

With this change we get the following indentation:

```
/ {
    cpus {
        cpu-map {
            cluster1 {
                core0 {
                    cpu = <&CPU0>;
                };
                core1 {
                    cpu = <&CPU1>;
                };
            };
        };
    };

    widget: pizza,feast@a00000 {
        compatible = "pizza,feast-v1";
        things = <1 2 3>;
    };
};
```
