### PR TITLE
respect the user's indent-tabs-mode

### DIFF
--- a/dts-mode.el
+++ b/dts-mode.el
@@ -105,7 +105,6 @@
 
   (set (make-local-variable 'comment-start) "/* ")
   (set (make-local-variable 'comment-end)   " */")
-  (set (make-local-variable 'indent-tabs-mode) nil)
   (set (make-local-variable 'comment-multi-line) t)
   (set (make-local-variable 'indent-line-function) 'dts-indent-line))
 


### PR DESCRIPTION
Not everyone (myself included) wants spaces instead of tabs.  Just leave
indent-tabs-mode alone.
