### PR TITLE
don't move the point when indenting

### DIFF
--- a/dts-mode.el
+++ b/dts-mode.el
@@ -89,7 +89,10 @@
 (defun dts-indent-line ()
   (interactive)
   (let ((indent (dts--calculate-indentation)))
-    (indent-line-to (* indent tab-width))))
+    (save-excursion
+      (indent-line-to (* indent tab-width)))
+    (when (or (bolp) (looking-back "^[[:space:]]+"))
+      (beginning-of-line-text))))
 
 (defalias 'dts-parent-mode
   (if (fboundp 'prog-mode) 'prog-mode 'fundamental-mode))


### PR DESCRIPTION
if the line is not empty and the point is in the text, keep the point at the same place in the text
otherwise (line is only indentation or point is in the indentation), move to the end of indentation